### PR TITLE
Add delete TrafficSplit functionality

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 DOCKER_REPO=nicholasjackson/istio-smi-controller
 DOCKER_VERSION=0.1.0
 SHELL := /bin/bash
+TMPDIR ?= /tmp
 
 build_docker_setup:
 	docker run --rm --privileged multiarch/qemu-user-static --reset -p yes
@@ -25,15 +26,15 @@ build_docker_push: build_docker_setup
 	docker buildx rm multi || true
 
 fetch_certs:
-	mkdir -p /tmp/k8s-webhook-server/serving-certs/
+	mkdir -p ${TMPDIR}/k8s-webhook-server/serving-certs/
 	
 	kubectl get secret smi-controller-webhook-certificate -n shipyard -o json | \
 		jq -r '.data."tls.crt"' | \
-		base64 -d > /tmp/k8s-webhook-server/serving-certs/tls.crt
+		base64 -d > ${TMPDIR}/k8s-webhook-server/serving-certs/tls.crt
 	
 	kubectl get secret smi-controller-webhook-certificate -n shipyard -o json | \
 		jq -r '.data."tls.key"' | \
-		base64 -d > /tmp/k8s-webhook-server/serving-certs/tls.key
+		base64 -d > ${TMPDIR}/k8s-webhook-server/serving-certs/tls.key
 
 run_local: fetch_certs
 	go run .

--- a/istio/client.go
+++ b/istio/client.go
@@ -14,6 +14,7 @@ import (
 // Client allows the creation of Istio objects from their SMI counterparts
 type Client interface {
 	CreateVirtualService(ctx context.Context, r client.Writer, ts *splitv1alpha4.TrafficSplit) error
+	DeleteVirtualService(ctx context.Context, r client.Writer, ts *splitv1alpha4.TrafficSplit) error
 }
 
 // IstioClient is a concrete implementation of Client
@@ -67,4 +68,16 @@ func (ic *IstioClient) CreateVirtualService(ctx context.Context, r client.Writer
 	vs.Spec.Http = []*networkingv1beta1.HTTPRoute{httpRoute}
 
 	return r.Create(ctx, vs, &client.CreateOptions{})
+}
+
+func (ic *IstioClient) DeleteVirtualService(ctx context.Context, r client.Writer, ts *splitv1alpha4.TrafficSplit) error {
+	ic.lazyRegisterIstioTypesToScheme(r.(client.Client))
+
+	vs := &v1beta1.VirtualService{}
+
+	// the client only need the name and namespace to delete the resource
+	vs.ObjectMeta.Name = ts.ObjectMeta.Name
+	vs.ObjectMeta.Namespace = ts.ObjectMeta.Namespace
+
+	return r.Delete(ctx, vs, &client.DeleteOptions{})
 }

--- a/istio/client_test.go
+++ b/istio/client_test.go
@@ -41,3 +41,17 @@ func TestCreateVirtualServiceCallsCreateWithValidObject(t *testing.T) {
 		require.Equal(t, be.Service, vs.Spec.Http[0].Route[i].Destination.Subset)
 	}
 }
+
+func TestDeleteVirtualServiceCallsCreateWithValidObject(t *testing.T) {
+	is, mcc := setupClientTests(t)
+	mcc.On("Delete", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+	ts := &splitv1alpha4.TrafficSplit{}
+
+	is.DeleteVirtualService(context.Background(), mcc, ts)
+
+	vs := getCalls(&mcc.Mock, "Delete")[0].Arguments[1].(*v1beta1.VirtualService)
+
+	require.Equal(t, vs.ObjectMeta.Name, ts.ObjectMeta.Name)
+	require.Equal(t, vs.ObjectMeta.Namespace, ts.ObjectMeta.Namespace)
+
+}

--- a/istio/mocks_test.go
+++ b/istio/mocks_test.go
@@ -19,6 +19,11 @@ func (mc *MockClient) CreateVirtualService(ctx context.Context, r client.Writer,
 	return args.Error(0)
 }
 
+func (mc *MockClient) DeleteVirtualService(ctx context.Context, r client.Writer, ts *splitv1alpha4.TrafficSplit) error {
+	args := mc.Called(ctx, r, ts)
+	return args.Error(0)
+}
+
 // MockWriter is a mock implementation of the contoller Writer interface
 type MockControllerClient struct {
 	mock.Mock

--- a/istio/split.go
+++ b/istio/split.go
@@ -70,5 +70,12 @@ func (l *API) DeleteTrafficSplit(
 
 	log.Info("DeleteTrafficSplit called", "api", "v1alpha4", "target", ts)
 
+	err := l.client.DeleteVirtualService(ctx, r, ts)
+	if err != nil {
+		log.Error(err, "Unable to delete Istio VirtualService")
+
+		return ctrl.Result{Requeue: true}, err
+	}
+
 	return ctrl.Result{}, nil
 }

--- a/istio/split_test.go
+++ b/istio/split_test.go
@@ -21,3 +21,16 @@ func TestCreateVirtualService(t *testing.T) {
 
 	mc.AssertCalled(t, "CreateVirtualService", ctx, mcc, ts)
 }
+
+func TestDeleteVirtualService(t *testing.T) {
+	api, mc, mcc := setupTests(t)
+	mc.On("DeleteVirtualService", mock.Anything, mock.Anything, mock.Anything).Return(nil)
+
+	ctx := context.Background()
+	ts := &splitv1alpha4.TrafficSplit{}
+	lgr := &logr.DiscardLogger{}
+
+	api.DeleteTrafficSplit(ctx, mcc, lgr, ts)
+
+	mc.AssertCalled(t, "DeleteVirtualService", ctx, mcc, ts)
+}

--- a/shipyard/controller.hcl
+++ b/shipyard/controller.hcl
@@ -40,6 +40,7 @@ variable "install_example_app" {
 
 module "smi-controller" {
   #source = "/home/nicj/go/src/github.com/shipyard-run/blueprints/modules/kubernetes-smi-controller"
+  #source = "/Users/keith/Projects/blueprints/modules/kubernetes-smi-controller"
   source = "github.com/shipyard-run/blueprints/modules/kubernetes-smi-controller"
 }
 

--- a/shipyard/istio.hcl
+++ b/shipyard/istio.hcl
@@ -7,5 +7,6 @@ variable "istio_k8s_network" {
 }
 
 module "istio" {
+  #source = "/Users/keith/Projects/blueprints/modules//kubernetes-istio"
   source = "github.com/shipyard-run/blueprints/modules//kubernetes-istio"
 }

--- a/test/features/split.feature
+++ b/test/features/split.feature
@@ -117,3 +117,37 @@ Feature: split.smi-spec.io
           methods: ["*"]
     ```
     Then I expect 1 Istio "VirtualService" named "ab-test" to have been created
+
+  @split
+  Scenario: Delete alpha1 TrafficSplit
+    Given the server is running
+    And the following resource exists
+    ```
+      apiVersion: split.smi-spec.io/v1alpha1
+      kind: TrafficSplit
+      metadata:
+        name: trafficsplit-sample
+      spec:
+        service: foo
+        backends:
+          - service: bar
+            weight: 50m
+          - service: baz
+            weight: 50m
+    ```
+    And I verify that 1 Istio "VirtualService" named "trafficsplit-sample" exists
+    When I delete the following resource
+    ```
+      apiVersion: split.smi-spec.io/v1alpha1
+      kind: TrafficSplit
+      metadata:
+        name: trafficsplit-sample
+      spec:
+        service: foo
+        backends:
+          - service: bar
+            weight: 50m
+          - service: baz
+            weight: 50m
+    ```
+    Then I expect no Istio "VirtualService" named "trafficsplit-sample" to exist

--- a/test/features/split.feature
+++ b/test/features/split.feature
@@ -1,5 +1,5 @@
 Feature: split.smi-spec.io
-  In order to test the TrafficTarget
+  In order to test the TrafficSplit
   As a developer
   I need to ensure the specification is accepted by the server
 
@@ -20,6 +20,7 @@ Feature: split.smi-spec.io
           - service: baz
             weight: 50m
     ```
+    Then I expect 1 Istio "VirtualService" named "trafficsplit-sample" to have been created
   
   @split
   Scenario: Apply alpha2 TrafficSplit
@@ -38,6 +39,7 @@ Feature: split.smi-spec.io
           - service: baz
             weight: 50
     ```
+    Then I expect 1 Istio "VirtualService" named "trafficsplit-sample" to have been created
   
   @split @alpha3
   Scenario: Apply alpha3 TrafficSplit
@@ -76,6 +78,7 @@ Feature: split.smi-spec.io
           pathRegex: "/ping"
           methods: ["*"]
     ```
+    Then I expect 1 Istio "VirtualService" named "ab-test" to have been created
   
   @split/alpha4
   Scenario: Apply alpha4 TrafficSplit
@@ -151,3 +154,121 @@ Feature: split.smi-spec.io
             weight: 50m
     ```
     Then I expect no Istio "VirtualService" named "trafficsplit-sample" to exist
+
+  @split
+  Scenario: Delete alpha2 TrafficSplit
+    Given the server is running
+    And the following resource exists
+    ```
+      apiVersion: split.smi-spec.io/v1alpha2
+      kind: TrafficSplit
+      metadata:
+        name: trafficsplit-sample
+      spec:
+        service: foo
+        backends:
+          - service: bar
+            weight: 50
+          - service: baz
+            weight: 50
+    ```
+    And I verify that 1 Istio "VirtualService" named "trafficsplit-sample" exists
+    When I delete the following resource
+    ```
+      apiVersion: split.smi-spec.io/v1alpha2
+      kind: TrafficSplit
+      metadata:
+        name: trafficsplit-sample
+      spec:
+        service: foo
+        backends:
+          - service: bar
+            weight: 50
+          - service: baz
+            weight: 50
+    ```
+    Then I expect no Istio "VirtualService" named "trafficsplit-sample" to exist
+  
+  @split @alpha3
+  Scenario: Delete alpha3 TrafficSplit
+    Given the server is running
+    And the following resource exists
+    ```
+      apiVersion: split.smi-spec.io/v1alpha3
+      kind: TrafficSplit
+      metadata:
+        name: ab-test
+      spec:
+        service: website
+        matches:
+        - kind: HTTPRouteGroup
+          name: ab-test
+          apiGroup: specs.smi-spec.io
+        backends:
+        - service: website-v1
+          weight: 0
+        - service: website-v2
+          weight: 100
+    ```
+    And I verify that 1 Istio "VirtualService" named "ab-test" exists
+    When I delete the following resource
+    ```
+      apiVersion: split.smi-spec.io/v1alpha3
+      kind: TrafficSplit
+      metadata:
+        name: ab-test
+      spec:
+        service: website
+        matches:
+        - kind: HTTPRouteGroup
+          name: ab-test
+          apiGroup: specs.smi-spec.io
+        backends:
+        - service: website-v1
+          weight: 0
+        - service: website-v2
+          weight: 100
+    ```
+    Then I expect no Istio "VirtualService" named "ab-test" to exist
+  
+  @split @alpha4
+  Scenario: Delete alpha4 TrafficSplit
+    Given the server is running
+    And the following resource exists
+    ```
+      apiVersion: split.smi-spec.io/v1alpha4
+      kind: TrafficSplit
+      metadata:
+        name: ab-test
+      spec:
+        service: website
+        matches:
+        - kind: HTTPRouteGroup
+          name: ab-test
+          apiGroup: specs.smi-spec.io
+        backends:
+        - service: website-v1
+          weight: 0
+        - service: website-v2
+          weight: 100
+    ```
+    And I verify that 1 Istio "VirtualService" named "ab-test" exists
+    When I delete the following resource
+    ```
+      apiVersion: split.smi-spec.io/v1alpha4
+      kind: TrafficSplit
+      metadata:
+        name: ab-test
+      spec:
+        service: website
+        matches:
+        - kind: HTTPRouteGroup
+          name: ab-test
+          apiGroup: specs.smi-spec.io
+        backends:
+        - service: website-v1
+          weight: 0
+        - service: website-v2
+          weight: 100
+    ```
+    Then I expect no Istio "VirtualService" named "ab-test" to exist

--- a/test/istio.go
+++ b/test/istio.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"istio.io/client-go/pkg/apis/networking/v1beta1"
+	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/scheme"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -35,6 +36,35 @@ func cleanupIstio() {
 	if err != nil {
 		fmt.Println("Error removing Istio VirtualService", err)
 	}
+}
+
+func iExpectNoIstioNamedToExist(crd, name string) error {
+	c := getK8sConfig()
+	kc, err := client.New(c, client.Options{Scheme: scheme.Scheme})
+	if err != nil {
+		panic(err)
+	}
+
+	return waitForComplete(
+		30*time.Second,
+		func() error {
+			switch crd {
+			case "VirtualService":
+				selector := fields.SelectorFromSet(fields.Set{
+					"metadata.name": name,
+				})
+				vsList := &v1beta1.VirtualServiceList{}
+				kc.List(context.Background(), vsList, &client.ListOptions{FieldSelector: selector})
+				if length := len(vsList.Items); length != 0 {
+					return fmt.Errorf("expected 0 resources; got %d", length)
+				}
+
+				return nil
+			}
+
+			return fmt.Errorf("Type %s, is not configured", crd)
+		},
+	)
 }
 
 func iExpectIstioNamedToHaveBeenCreated(count int, crd, name string) error {

--- a/test/main.go
+++ b/test/main.go
@@ -115,9 +115,13 @@ func initializeScenario(ctx *godog.ScenarioContext) {
 
 	ctx.Step(`^the server is running$`, theServerIsRunning)
 	ctx.Step(`^I create the following resource$`, iCreateTheFollowingResource)
+	ctx.Step(`^I delete the following resource$`, iDeleteTheFollowingResource)
 	ctx.Step(`^I expect "([^"]*)" to be called (\d+) time$`, iExpectToBeCalled)
+	ctx.Step(`^the following resource exists$`, iCreateTheFollowingResource)
 
 	ctx.Step(`^I expect (\d+) Istio "([^"]*)" named "([^"]*)" to have been created$`, iExpectIstioNamedToHaveBeenCreated)
+	ctx.Step(`^I verify that (\d+) Istio "([^"]*)" named "([^"]*)" exists`, iExpectIstioNamedToHaveBeenCreated)
+	ctx.Step(`^I expect no Istio "([^"]*)" named "([^"]*)" to exist`, iExpectNoIstioNamedToExist)
 
 	ctx.AfterScenario(func(s *messages.Pickle, err error) {
 		cleanupResources()
@@ -308,6 +312,27 @@ func iCreateTheFollowingResource(arg1 *messages.PickleStepArgument_PickleDocStri
 
 	// import the file to the kubernetes cluster
 	err = k8sClient.Apply([]string{f.Name()}, true)
+	return err
+}
+
+func iDeleteTheFollowingResource(arg1 *messages.PickleStepArgument_PickleDocString) error {
+	// save the document to a temporary file
+	f, err := ioutil.TempFile("", "*.yaml")
+	if err != nil {
+		return err
+	}
+
+	// cleanup
+	defer os.Remove(f.Name())
+
+	// write the document to the file
+	_, err = f.WriteString(arg1.GetContent())
+	if err != nil {
+		return err
+	}
+
+	// delete the file from the kubernetes cluster
+	err = k8sClient.Delete([]string{f.Name()})
 	return err
 }
 


### PR DESCRIPTION
This PR gives the Istio SMI controller the ability to delete VirtualService manifests when the corresponding TrafficSplit resource is deleted